### PR TITLE
Move dependency-ci from pr_status to status

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,6 @@
 delete_merged_branches = true
 
-pr_status = [
-    "dependency-ci",
-]
 status = [
     "continuous-integration/travis-ci/push",
+    "dependency-ci",
 ]


### PR DESCRIPTION
It gets fired there as well, and won't run into the issue where I r+ a PR in the seconds before it comes in

It's also better practice to check it on the bors merge, I just put it there because I thought it didn't fire on bors's pushes

bors: r+