### PR TITLE
Remove package.include key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["CAD97 <cad97@cad97.com>"]
 description = "Upload documentation straight to GitHub Pages, maintaining branch seperation and history"
 
-include = ["/src/**/*", "Cargo.toml", "/LICENSE-APACHE", "/LICENSE-MIT", "/README.md"]
-
 homepage = "https://github.com/crate-ci/cargo-ghp-upload"
 repository = "https://github.com/crate-ci/cargo-ghp-upload.git"
 readme = "README.md"


### PR DESCRIPTION
It's more effort than it's worth for this small crate.
The important excludes are covered by git ignores.

bors: r+